### PR TITLE
Update GenericDAO.java

### DIFF
--- a/WSRTool/src/com/application/GenericDAO.java
+++ b/WSRTool/src/com/application/GenericDAO.java
@@ -25,12 +25,12 @@ public class GenericDAO<T> implements GenericDAOInterface<T> {
 	private Transaction tx = null;
 
 	public GenericDAO(Class<T> type) {
-		session = HibernateUtil.getSessionFactory().openSession();
 		this.classType = type;
 	}
 
 	@Override
 	public Integer create(T t) {
+		session = HibernateUtil.getSessionFactory().openSession();
 		Integer id = null;
 		try {
 			tx = session.beginTransaction();
@@ -48,6 +48,7 @@ public class GenericDAO<T> implements GenericDAOInterface<T> {
 
 	@Override
 	public Set<T> get() {
+		session = HibernateUtil.getSessionFactory().openSession();
 		Set<T> objSet = new HashSet<>(0);
 		try {
 			tx = session.beginTransaction();
@@ -71,6 +72,7 @@ public class GenericDAO<T> implements GenericDAOInterface<T> {
 
 	@Override
 	public T getById(Integer id) {
+		session = HibernateUtil.getSessionFactory().openSession();
 		T t = null;
 		try {
 			tx = session.beginTransaction();
@@ -90,6 +92,7 @@ public class GenericDAO<T> implements GenericDAOInterface<T> {
 
 	@Override
 	public T update(T t, Integer id) {
+		session = HibernateUtil.getSessionFactory().openSession();
 		T tmpT = null;
 		try {
 			tx = session.beginTransaction();
@@ -113,6 +116,7 @@ public class GenericDAO<T> implements GenericDAOInterface<T> {
 
 	@Override
 	public Integer delete(Integer id) {
+		session = HibernateUtil.getSessionFactory().openSession();
 		T t = null;
 		Integer returnVal = 200;
 		try {


### PR DESCRIPTION
session is not instantiated at the beginning of every CRUD operation. This was fixed due to the common bug of "Session/Entity Manager is closed."